### PR TITLE
Update v.1.0.3

### DIFF
--- a/scripts/JCOM_pipeline_blastnr.pbs
+++ b/scripts/JCOM_pipeline_blastnr.pbs
@@ -16,7 +16,7 @@
 
 ##load modules
 module load blast+
-module load diamond
+module load diamond/2.1.6
 
 # blastx
 function BlastxNR {

--- a/scripts/JCOM_pipeline_blastp_custom.pbs
+++ b/scripts/JCOM_pipeline_blastp_custom.pbs
@@ -15,7 +15,7 @@
 
 ## load modules
 module load blast
-module load diamond/2.0.9
+module load diamond/2.1.6
 
 db_basename=$(basename "$db")
 

--- a/scripts/JCOM_pipeline_blastxRVDB.pbs
+++ b/scripts/JCOM_pipeline_blastxRVDB.pbs
@@ -12,17 +12,17 @@
 # It will then extract the contigs that have a blast hit to the RVDB database which can be used in later steps such as Blastx against the NR and NT databases.
 
 #PBS -N blastx_RVDB_array
-#PBS -l select=1:ncpus=12:mem=60GB
+#PBS -l select=1:ncpus=12:mem=120GB
 #PBS -M jmif9945@uni.sydney.edu.au
 #PBS -m abe
 
 ##load modules
 module load blast
-module load diamond/2.0.9
+module load diamond/2.1.6
 
 # blastx
 function BlastxRVDB {
-    diamond blastx -q "$inpath"/"$library_id".contigs.fa -d "$db" -t "$tempdir" -o "$outpath"/"$library_id"_RVDB_blastx_results.txt -e 1E-10 -c1 -k 5 -b "$MEM" -p "$CPU" -f 6 qseqid qlen sseqid stitle pident length evalue --ultra-sensitive
+    diamond blastx -q "$inpath"/"$library_id".contigs.fa -d "$db" -t "$tempdir" -o "$outpath"/"$library_id"_RVDB_blastx_results.txt -e 1E-10 -c1 -k1 -b "$MEM" -p "$CPU" -f 6 qseqid qlen sseqid stitle pident length evalue --ultra-sensitive --iterate
 }
 
 #tool to extract contigs from trinity assembly Blast to fasta
@@ -47,7 +47,7 @@ inpath=/project/"$root_project"/"$project"/contigs/final_contigs # location of r
 outpath=/project/"$root_project"/"$project"/blast_results        # location of megahit output
 tempdir=/scratch/"$root_project"/
 CPU=12
-MEM=1
+MEM=2
 
 # cd working dir
 cd "$wd" || exit

--- a/scripts/JCOM_pipeline_blastxRVDB.sh
+++ b/scripts/JCOM_pipeline_blastxRVDB.sh
@@ -91,6 +91,6 @@ qsub -J "$jPhrase" \
     -e "/project/$root_project/$project/logs/blastxRVDB_^array_index^_$project_$(date '+%Y%m%d')_stderr.txt" \
     -v "project=$project,file_of_accessions=$file_of_accessions,root_project=$root_project,db=$db" \
     -q "$queue" \
-    -l "walltime=84:00:00" \
+    -l "walltime=90:00:00" \
     -P "$root_project" \
     /project/"$root_project"/"$project"/scripts/JCOM_pipeline_blastxRVDB.pbs

--- a/scripts/JCOM_pipeline_blastxRdRp.pbs
+++ b/scripts/JCOM_pipeline_blastxRdRp.pbs
@@ -17,7 +17,7 @@
 
 ##load modules
 module load blast
-module load diamond/2.0.9
+module load diamond/2.1.6
 
 # blastx
 function BlastxRdRp {

--- a/scripts/JCOM_pipeline_blastx_custom.pbs
+++ b/scripts/JCOM_pipeline_blastx_custom.pbs
@@ -15,7 +15,7 @@
 
 ##load modules
 module load blast
-module load diamond/2.0.9
+module load diamond/2.1.6
 
 db_basename=$(basename "$db")
 


### PR DESCRIPTION
- update diamond/2.0.9 -> diamond/2.1.6 across diamond blast scripts
- increase JCOM_pipeline_blastxRVDB default memory 60GB to 120GB to handle AGRF sized libs better
- JCOM_pipeline_blastxRVDB diamond -k5 changed to -k1 as we extra alignments are needed in an initial blast
- JCOM_pipeline_blastxRVDB diamond -b1 changed to -b2 (the default) to utilise the extra memory we give it
- JCOM_pipeline_blastxRVDB add --iterate so that diamond does an initial pass with low sens than moves to  --ultra-sensitive. This should improve mem and time. 